### PR TITLE
Refactorisation complète des entités JPA et validation du mapping Hibernate

### DIFF
--- a/src/main/java/com/nnk/springboot/domain/BidList.java
+++ b/src/main/java/com/nnk/springboot/domain/BidList.java
@@ -1,7 +1,10 @@
 package com.nnk.springboot.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.sql.Timestamp;
 
 /**
  * Entité représentant une offre (Bid) soumise sur la plateforme Poseidon Capital Solutions.
@@ -11,8 +14,34 @@ import jakarta.persistence.Table;
  * Elle n'était pas utile dans cette entité JPA, qui ne dépend pas de l'injection Spring.
  */
 
+@Getter
+@Setter
 @Entity
 @Table(name = "bidlist")
 public class BidList {
-    // TODO: Map columns in data table BIDLIST with corresponding java fields
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer bidListId;
+
+    String account;
+    String type;
+    Double bidQuantity;
+    Double askQuantity;
+    Double bid;
+    Double ask;
+    String benchmark;
+    Timestamp bidListDate;
+    String commentary;
+    String security;
+    String status;
+    String trader;
+    String book;
+    String creationName;
+    Timestamp creationDate;
+    String revisionName;
+    Timestamp revisionDate;
+    String dealName;
+    String dealType;
+    String sourceListId;
+    String side;
 }

--- a/src/main/java/com/nnk/springboot/domain/CurvePoint.java
+++ b/src/main/java/com/nnk/springboot/domain/CurvePoint.java
@@ -7,9 +7,22 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.sql.Timestamp;
 
-
+/**
+ * Entité représentant un point de courbe (CurvePoint) utilisé dans la gestion des courbes de taux.
+ * Chaque enregistrement correspond à un point défini par une courbe, une valeur et une date.
+ */
 @Entity
 @Table(name = "curvepoint")
 public class CurvePoint {
-    // TODO: Map columns in data table CURVEPOINT with corresponding java fields
+
+    @Id
+    @GeneratedValue (strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private Integer curveId;
+    private Timestamp asOfDate;
+    private Double term;
+    private Double value;
+    private Timestamp creationDate;
+
 }

--- a/src/main/java/com/nnk/springboot/domain/Rating.java
+++ b/src/main/java/com/nnk/springboot/domain/Rating.java
@@ -3,10 +3,26 @@ package com.nnk.springboot.domain;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
 import java.sql.Timestamp;
 
+/**
+ * Entité représentant la notation (Rating) attribuée à un instrument financier.
+ * Chaque enregistrement contient les différentes notations selon les agences Moody's, S&P et Fitch.
+ */
+@Getter
+@Setter
 @Entity
 @Table(name = "rating")
 public class Rating {
-    // TODO: Map columns in data table RATING with corresponding java fields
+    @Id
+    @GeneratedValue (strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String moodysRating;
+    private String sandPRating;
+    private String fitchRating;
+    private Integer orderNumber;
 }

--- a/src/main/java/com/nnk/springboot/domain/RuleName.java
+++ b/src/main/java/com/nnk/springboot/domain/RuleName.java
@@ -2,10 +2,29 @@ package com.nnk.springboot.domain;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
 import java.sql.Timestamp;
 
+/**
+ * Entité représentant une règle de validation (RuleName)
+ * utilisée dans l'application Poseidon Capital Solutions.
+ * Chaque règle contient un nom, une description et des expressions 'SQL/JSON' associées.
+ */
+@Getter
+@Setter
 @Entity
 @Table(name = "rulename")
 public class RuleName {
-    // TODO: Map columns in data table RULENAME with corresponding java fields
+    @Id
+    @GeneratedValue (strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String name;
+    private String description;
+    private String json;
+    private String template;
+    private String sqlStr;
+    private String sqlPart;
 }

--- a/src/main/java/com/nnk/springboot/domain/Trade.java
+++ b/src/main/java/com/nnk/springboot/domain/Trade.java
@@ -2,11 +2,44 @@ package com.nnk.springboot.domain;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
 import java.sql.Timestamp;
 
-
+/**
+ * Entité représentant une transaction (Trade) dans l'application Poseidon Capital Solutions.
+ * Chaque enregistrement correspond à une opération financière (achat/vente) effectuée par un trader.
+ *
+ * Contient les informations sur le compte, le type de transaction, les quantités, les prix,
+ * ainsi que les métadonnées (dates, statut, source, etc.).
+ */
+@Getter
+@Setter
 @Entity
 @Table(name = "trade")
 public class Trade {
-    // TODO: Map columns in data table TRADE with corresponding java fields
+    @Id
+    @GeneratedValue (strategy = GenerationType.IDENTITY)
+    private Integer tradeId;
+    private String account;
+    private String type;
+    private Double buyQuantity;
+    private Double sellQuantity;
+    private Double buyPrice;
+    private Double sellPrice;
+    private String benchmark;
+    private Timestamp tradeDate;
+    private String security;
+    private String status;
+    private String trader;
+    private String book;
+    private String creationName;
+    private Timestamp creationDate;
+    private String revisionName;
+    private Timestamp revisionDate;
+    private String dealName;
+    private String dealType;
+    private String sourceListId;
+    private String side;
 }


### PR DESCRIPTION
### Objectif  & Contexte
Refactoriser les entités JPA pour assurer un mapping propre, cohérent et fonctionnel avec Hibernate/MySQL, en préparation des futures étapes (CRUD et sécurité Spring Session).
Cette refactorisation fait suite à la mise à jour de l’infrastructure technique (Spring Boot 3.5.6, UTF-8 global, configuration multi-profils `.env`).  Elle pose les fondations d’un modèle JPA robuste, garantissant la compatibilité avec les versions récentes de Spring et Jakarta EE.

---

### Détails des changements 
#### **Refactorisation structurelle des entités :**
- Ajout des annotations `@Entity`, `@Id` et `@GeneratedValue(strategy = GenerationType.IDENTITY)`  
- Mappage complet des champs pour les classes :  
  `BidList`, `CurvePoint`, `Rating`, `RuleName`, `Trade`, `User`  
- Suppression des `TODO` restants et harmonisation des types de données  
- Adoption de Lombok (`@Getter`, `@Setter`) pour réduire le code boilerplate  

#### **Configuration et cohérence JPA/Hibernate :**
- Vérification du dialecte MySQL (`org.hibernate.dialect.MySQLDialect`)  
- Synchronisation automatique du schéma via `spring.jpa.hibernate.ddl-auto=update`  
- Validation du mapping et génération correcte des tables correspondantes  

---

### Vérifications effectuées    
- [x] Variables d'environnement chargées via `.env` 
- [x] Démarrage validé sur les profils `dev` et `test`  
- [x] Connexion MySQL fonctionnelle sur bases `demo` et `test`  
- [x] Création et mise à jour automatique des tables MySQL confirmées  (mais tables vides sans données)
- [x] Aucune erreur de mapping ou d'injection détectée  
- [ ] Tests JUnit à corriger dans une future branche `feature/fix-tests`