### PR TITLE
Refactor - Intégration de MapStruct dans le module Rule (remplacement du mapping manuel)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <java.version>17</java.version> <!-- set the version of java -->
         <jacoco.version>0.8.12</jacoco.version> <!-- set the version of jacoco -->
         <lombok.version>1.18.30</lombok.version> <!-- set the version of lombok -->
+        <mapstruct.version>1.6.3</mapstruct.version> <!-- set the version of mapstruct -->
     </properties>
 
     <dependencies>
@@ -92,6 +93,28 @@
             <artifactId>java-dotenv</artifactId>
             <version>5.2.2</version>
         </dependency>
+        <!-- =============================================================== -->
+        <!-- === MapStruct : Moteur de génération automatique de mappers === -->
+        <!-- =============================================================== -->
+        <!-- MapStruct simplifie la conversion entre les entités JPA et les DTOs.
+             Il génère automatiquement le code de mapping (ex. RuleMapperImpl.java) à la compilation, à partir d'interfaces annotées avec @Mapper.
+             Pas de code "convertToDto" / "convertToEntity" manuel -->
+        <!-- Librairie principale (runtime) :
+        Fournit les annotations (@Mapper, @Mapping, etc.) utilisées dans le code source -->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+        <!-- Processeur d'annotations (compiler time only) :
+        C'est lui qui, pendant la compilation, analyse les interfaces @Mapper et génère automatiquement les classes d'implémentation (ex : RuleMapperImpl).
+        Marqué en <scope>provided</scope> pour ne pas être inclus dans le JAR final, car il n'est nécessaire qu'au moment de la compilation. -->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${mapstruct.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
@@ -142,6 +165,11 @@
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
                             <version>${lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/src/main/java/com/poseidon/tradingapp/controllers/RuleController.java
+++ b/src/main/java/com/poseidon/tradingapp/controllers/RuleController.java
@@ -6,7 +6,6 @@ import com.poseidon.tradingapp.exceptions.RuleNotFoundException;
 import com.poseidon.tradingapp.services.RuleService;
 import com.poseidon.tradingapp.utils.MessageUtils;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -22,14 +21,18 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 @Controller
 public class RuleController {
 
-    @Autowired
-    private RuleService ruleService;
+    private final RuleService ruleService;
+
+    public RuleController(RuleService ruleService) {
+        this.ruleService = ruleService;
+    }
 
     /**
      * Affiche la liste des règles existantes.
      */
     @GetMapping("/rule/list")
     public String home(Model model) {
+        log.info("GET /rule/list - Récupération de la liste des règles");
         model.addAttribute("rules", ruleService.getAllRules());
         return "rule/list";
     }
@@ -39,6 +42,7 @@ public class RuleController {
      */
     @GetMapping("/rule/add")
     public String showAddForm(Model model) {
+        log.info("GET /rule/add - Affichage du formulaire d'ajout de règle");
         model.addAttribute("rule", new RuleDto());
         return "rule/add";
     }
@@ -48,8 +52,11 @@ public class RuleController {
      */
     @PostMapping("/rule/validate")
     public String validate(@Valid @ModelAttribute("rule") RuleDto ruleDto, BindingResult result, RedirectAttributes redirectAttributes) {
+        log.debug("POST /rule/validate - Données reçues : {}", ruleDto);
+
         // Si des champs obligatoires sont manquants ou invalides, on reste sur la page d'ajout de règle
         if (result.hasErrors()) {
+            log.warn("Validation échouée pour la création de règle : {}", ruleDto.getName());
             return "rule/add";
         }
 
@@ -60,8 +67,8 @@ public class RuleController {
             log.info("Règle ajoutée avec succès : {}", ruleDto.getName());
         } catch (RuleAlreadyExistsException e) {
             // Message utilisateur clair + message technique pour le dev
-            result.rejectValue("name", "error.rule", MessageUtils.RULE_DUPLICATE);
             log.warn("Création refusée (doublon) : {}", e.getMessage());
+            result.rejectValue("name", "error.rule", MessageUtils.RULE_DUPLICATE);
             return "rule/add";
         }
 
@@ -71,6 +78,7 @@ public class RuleController {
 
     @GetMapping("/rule/update/{id}")
     public String showUpdateForm(@PathVariable("id") Integer id, Model model, RedirectAttributes redirectAttributes) {
+        log.info("GET /rule/update/{} - Chargement du formulaire d'édition", id);
         try {
             RuleDto ruleDto = ruleService.getRuleById(id);
             model.addAttribute("rule", ruleDto);
@@ -87,7 +95,9 @@ public class RuleController {
     @PostMapping("/rule/update/{id}")
     public String updateRule(@PathVariable("id") Integer id, @Valid @ModelAttribute("rule") RuleDto ruleDto,
                              BindingResult result, RedirectAttributes redirectAttributes) {
+        log.debug("POST /rule/update/{} - Données reçues : {}", id, ruleDto);
         if (result.hasErrors()) {
+            log.warn("Validation échouée pour la mise à jour de la règle id={}", id);
             // Si des erreurs de validation, on reste sur la page d'édition de la règle
             return "rule/update";
         }
@@ -110,6 +120,7 @@ public class RuleController {
 
     @GetMapping("/rule/delete/{id}")
     public String deleteRule(@PathVariable("id") Integer id, RedirectAttributes redirectAttributes) {
+        log.info("GET /rule/delete/{} - Suppression d'une règle", id);
         try {
             ruleService.deleteRule(id);
             redirectAttributes.addFlashAttribute("successMessage", MessageUtils.RULE_DELETE_SUCCESS);

--- a/src/main/java/com/poseidon/tradingapp/mappers/RuleMapper.java
+++ b/src/main/java/com/poseidon/tradingapp/mappers/RuleMapper.java
@@ -1,0 +1,24 @@
+package com.poseidon.tradingapp.mappers;
+
+import com.poseidon.tradingapp.domain.Rule;
+import com.poseidon.tradingapp.dto.RuleDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+/**
+ * Mapper MapStruct pour la conversion entre Rule (entité JPA) et RuleDto (objet de transfert de données).
+ * <p>
+ * Géré automatiquement par MapStruct en générant une implémentation (RuleMapperImpl.java) à la compilation,
+ * effectuant ainsi un mapping champ à champ
+ */
+@Mapper(componentModel = "spring") // permet l'injection Spring @Autowired
+public interface RuleMapper {
+
+    RuleDto toDto (Rule entity);
+    Rule toEntity (RuleDto dto);
+
+    // Méthode spéciale pour mettre à jour une entité existante à partir d'un DTO
+    @Mapping(target = "ruleId", ignore = true) // on ignore l'ID pour ne pas l'écraser
+    void updateEntityFromDto(RuleDto dto, @MappingTarget Rule entity); //@MappingTarget pour dire ce n'est pas un objet à créer, mais un objet existant à mettre à jour.
+}

--- a/src/main/java/com/poseidon/tradingapp/services/RuleService.java
+++ b/src/main/java/com/poseidon/tradingapp/services/RuleService.java
@@ -4,6 +4,7 @@ import com.poseidon.tradingapp.domain.Rule;
 import com.poseidon.tradingapp.dto.RuleDto;
 import com.poseidon.tradingapp.exceptions.RuleAlreadyExistsException;
 import com.poseidon.tradingapp.exceptions.RuleNotFoundException;
+import com.poseidon.tradingapp.mappers.RuleMapper;
 import com.poseidon.tradingapp.repositories.RuleRepository;
 import org.springframework.stereotype.Service;
 
@@ -12,50 +13,58 @@ import java.util.Optional;
 
 /**
  * Service métier pour la gestion des règles (Rule)
- * Contient la logique de validation, de vérification de doublons et de conversion DTO - Entité.
+ * Contient la logique de validation, de vérification de doublons et de conversion DTO - Entité via MapStruct
  */
 @Service
 public class RuleService {
     private final RuleRepository ruleRepository;
+    private final RuleMapper ruleMapper;
 
-    public RuleService (RuleRepository ruleRepository){
+    public RuleService (RuleRepository ruleRepository, RuleMapper ruleMapper){
         this.ruleRepository=ruleRepository;
+        this.ruleMapper = ruleMapper;
     }
 
     /**
      * Crée une nouvelle règle à partir d'un DTO.
      * Vérifie que le nom n'existe pas déjà avant d'enregistrer.
      */
-    public Rule createRule(RuleDto dto) {
+    public RuleDto createRule(RuleDto dto) {
         // vérification des doublons
         if (ruleRepository.existsByName(dto.getName())){
             throw new RuleAlreadyExistsException("Une règle porte le même nom : " + dto.getName());
         }
-        // conversion DTO → Entity
-        Rule rule = convertToEntity(dto);
-        // sauvegarde en base
-        return ruleRepository.save(rule);
+        // Sauvegarde l'entité et retourne le DTO créé
+        Rule saved = ruleRepository.save(ruleMapper.toEntity(dto));
+        return ruleMapper.toDto(saved);
     }
 
     /**
      * Récupère toutes les règles existantes.
      */
-    public List<Rule> getAllRules() {
-        return ruleRepository.findAll();
+    public List<RuleDto> getAllRules() {
+
+        return ruleRepository.findAll()
+                .stream()
+                .map(ruleMapper::toDto)
+                .toList();
     }
 
+    /**
+     * Récupère une règle par son ID.
+     */
     public RuleDto getRuleById(Integer id) {
         Optional<Rule> ruleOpt = ruleRepository.findById(id);
         if (ruleOpt.isEmpty()) {
             throw new RuleNotFoundException("Impossible d'afficher la règle : ID " + id);
         }
-        return convertToDto(ruleOpt.get());
+        return ruleMapper.toDto(ruleOpt.get());
     }
 
     /**
      * Met à jour une règle existante.
      */
-    public Rule updateRule(Integer id, RuleDto dto) {
+    public RuleDto updateRule(Integer id, RuleDto dto) {
         Rule existingRule = ruleRepository.findById(id)
                 .orElseThrow(() -> new RuleNotFoundException("Mise à jour impossible : aucune règle trouvée avec l'ID " + id));
 
@@ -64,16 +73,12 @@ public class RuleService {
             throw new RuleAlreadyExistsException("Une autre règle porte déjà le nom : " + dto.getName());
         }
 
-        // Met à jour les champs
-        existingRule.setName(dto.getName());
-        existingRule.setDescription(dto.getDescription());
-        existingRule.setJson(dto.getJson());
-        existingRule.setTemplate(dto.getTemplate());
-        existingRule.setSqlStr(dto.getSqlStr());
-        existingRule.setSqlPart(dto.getSqlPart());
+        // Met à jour les champs de l'entité existante à partir du DTO (MapStruct gère le mapping champ par champ automatiquement)
+        ruleMapper.updateEntityFromDto(dto, existingRule);
 
-        // Sauvegarde et retourne l'entité mise à jour
-        return ruleRepository.save(existingRule);
+        // Sauvegarde l'entité et retourne le DTO mis à jour
+        Rule updated = ruleRepository.save(existingRule);
+        return ruleMapper.toDto(updated);
     }
 
     /**
@@ -83,35 +88,5 @@ public class RuleService {
         Rule rule = ruleRepository.findById(id)
                 .orElseThrow(() -> new RuleNotFoundException("Suppression impossible : aucune règle trouvée avec l'ID " + id));
         ruleRepository.delete(rule);
-    }
-
-    /**
-     * Convertit un RuleDto vers une entité Rule.
-     */
-    private Rule convertToEntity(RuleDto dto) {
-        Rule entity = new Rule();
-        entity.setRuleId(dto.getRuleId());
-        entity.setName(dto.getName());
-        entity.setDescription(dto.getDescription());
-        entity.setJson(dto.getJson());
-        entity.setTemplate(dto.getTemplate());
-        entity.setSqlStr(dto.getSqlStr());
-        entity.setSqlPart(dto.getSqlPart());
-        return entity;
-    }
-
-    /**
-     * Convertit une entité Rule vers un RuleDto.
-     */
-    private RuleDto convertToDto(Rule entity) {
-        RuleDto dto = new RuleDto();
-        dto.setRuleId(entity.getRuleId());
-        dto.setName(entity.getName());
-        dto.setDescription(entity.getDescription());
-        dto.setJson(entity.getJson());
-        dto.setTemplate(entity.getTemplate());
-        dto.setSqlStr(entity.getSqlStr());
-        dto.setSqlPart(entity.getSqlPart());
-        return dto;
     }
 }


### PR DESCRIPTION
## Objectif  
Refactorisation technique du module **Rule** afin d'intégrer **MapStruct** pour la conversion entre les entités JPA (`Rule`) et les objets de transfert de données (`RuleDto`).  Cette amélioration remplace les méthodes de mapping manuelles par un système automatique, performant et maintenable.

---

## Détails des modifications

### **1. Mise à jour du `pom.xml`**
- Ajout des dépendances `mapstruct` et `mapstruct-processor`.
- Définition de la propriété `mapstruct.version`.
- Configuration du `maven-compiler-plugin` pour activer le traitement des annotations.
- Documentation détaillée expliquant le rôle de chaque dépendance :
  - `mapstruct` → annotations et API du mapper.
  - `mapstruct-processor` → génération du code (`RuleMapperImpl.java`) à la compilation.

### **2. Création du `RuleMapper`**
- Nouvelle interface `RuleMapper` dans `com.poseidon.tradingapp.mappers`.
- Annotations :
  - `@Mapper(componentModel = "spring")` → intégration automatique via Spring.
  - `@MappingTarget` pour la mise à jour d'une entité existante.
- Méthodes implémentées :
  - `RuleDto toDto(Rule entity)`
  - `Rule toEntity(RuleDto dto)`
  - `void updateEntityFromDto(RuleDto dto, @MappingTarget Rule entity)`
- Génération automatique du code de conversion par MapStruct (classe `RuleMapperImpl`).

### **3. Refactorisation du `RuleService`**
- Suppression des méthodes manuelles `convertToDto()` et `convertToEntity()`.
- Injection du `RuleMapper` pour automatiser la conversion.
- Simplification des méthodes :
  - `createRule()` → conversion DTO → entité → DTO.
  - `getAllRules()` → conversion de toutes les entités en liste de DTOs.
  - `getRuleById()` et `updateRule()` → conversion automatique via MapStruct.
- Retour uniforme des méthodes en **`RuleDto`** pour cohérence avec la couche contrôleur.

### **4. Refactorisation du `RuleController`**
- Passage à une **injection par constructeur** (meilleure pratique Spring).
- Amélioration des logs :
  - `INFO` → pour les actions réussies.
  - `WARN` → pour les exceptions métier (`RuleAlreadyExistsException`, `RuleNotFoundException`).
  - `DEBUG` → pour les données reçues depuis les formulaires.
- Adaptation des appels au service après le refactor MapStruct.

---

## Résultat attendu
- Code plus concis et maintenable.  
- Conversions automatiques DTO ↔ entité via MapStruct.  
- Meilleure séparation des responsabilités entre couches.  
- Aucune régression fonctionnelle (CRUD Rule inchangé).

---

## Étapes suivantes  
- Création d'une nouvelle branche : `feature/rule-tests`  
  → ajout des tests unitaires et d'intégration (`RuleServiceTest`, `RuleMapperTest` `RuleControllerIT`).
