### PR TITLE
Story 7 : Mise en place complète de la sécurité (Authentication + BCrypt + Roles + Documentation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,42 @@
 4. Create database with name "demo" as configuration in application.properties
 5. Run sql script to create table doc/data.sql
 
+## Initialisation de la base MySQL (profil DEV)
+
+Lors du tout **premier démarrage** de l'application en environnement **DEV**, Spring doit exécuter automatiquement les scripts SQL situés dans :
+
+- `src/main/resources/database/schema.sql`
+- `src/main/resources/database/data.sql`
+
+Pour que cette initialisation soit bien effectuée, la configuration suivante doit être activée dans `application-dev.properties` :
+
+spring.sql.init.mode=always
+
+Cela permet :
+
+- de créer automatiquement la table `users`
+- d'insérer les comptes initiaux `admin/admin` et `user/user`
+- d'appliquer la contrainte d'unicité sur `username`
+
+### Après le premier démarrage
+
+Une fois la base initialisée, il est recommandé de repasser la propriété à :
+
+spring.sql.init.mode=never
+
+Ainsi, on évite que :
+
+- les données soient réinsérées à chaque lancement.
+- des erreurs telles que `Duplicate entry 'admin' for key 'username_UNIQUE'` apparaissent
+
+Résumé
+
+| Étape               | Valeur recommandée                      |
+|---------------------|-----------------------------------------|
+| Premier lancement   | spring.sql.init.mode=always             |
+| Lancements suivants | spring.sql.init.mode=never              |
+
+
 ## Structure du projet et bonnes pratiques
 
 1. **Domain** → Contient les entités JPA (ex : `Rule`)

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,32 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+
+        <!--
+        Active l'intégration entre Thymeleaf et Spring Security.
+
+        Grâce à cette dépendance :
+            * Thymeleaf peut accéder automatiquement au SecurityContext de Spring Security
+            (équivalent Java : SecurityContextHolder.getContext().getAuthentication())
+            * on peut afficher le nom de l'utilisateur connecté :
+                 • sec : authentication="name"
+                 • ${#authentication.name}
+            * on peut afficher / masquer des sections selon les rôles :
+                 • sec : authorize="hasRole('ADMIN')"
+            * ${#authentication.*} devient disponible dans toutes les vues.
+
+        Sans cette dépendance :
+            * les balises "sec :" NE fonctionnent PAS
+            * ${#authentication} peut être null dans les templates
+             → erreurs du type : EL1007E (propriété 'name' introuvable, car authentication = null).
+
+        Cette dépendance est indispensable dès que l'interface utilise le contexte de sécurité (utilisateur connecté, rôles, conditions d'accès).
+        -->
+        <dependency>
+            <groupId>org.thymeleaf.extras</groupId>
+            <artifactId>thymeleaf-extras-springsecurity6</artifactId>
+        </dependency>
+
         <!-- Tests de sécurité Spring (MockMvc + @WithMockUser, etc.) -->
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/src/main/java/com/poseidon/tradingapp/config/SpringSecurityConfiguration.java
+++ b/src/main/java/com/poseidon/tradingapp/config/SpringSecurityConfiguration.java
@@ -1,9 +1,12 @@
 package com.poseidon.tradingapp.config;
 
+import com.poseidon.tradingapp.repositories.UserRepository;
+import com.poseidon.tradingapp.security.CustomUserDetailsService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -34,18 +37,28 @@ public class SpringSecurityConfiguration {
                 // ATTENTION : À réactiver dès que les formulaires utilisateurs (login, création, etc.) seront finalisés.
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(form -> form
-                        .loginPage("/app/login")             // page de login personnalisée
+                        .loginPage("/app/login")             // URL GET pour afficher le formulaire de login
+                        .loginProcessingUrl("/app/login")    // URL POST TRAITÉE par Spring Security
                         .defaultSuccessUrl("/bidList/list", true)  // redirection après succès
                         .failureUrl("/app/login?error=true") // gestion des erreurs
                         .permitAll()
+                )
+                .exceptionHandling(ex -> ex
+                        .accessDeniedPage("/app/error")
                 )
                 .logout(logout -> logout
                         .logoutUrl("/app-logout")            // action logout
                         .logoutSuccessUrl("/")               // après déconnexion → home
                         .permitAll()
-                );
+        );
 
         return http.build();
+    }
+
+    // Active l'authentification Spring Security via les utilisateurs stockés en base MySQL (username, mot de passe BCrypt, rôle)
+    @Bean
+    public UserDetailsService userDetailsService(UserRepository userRepository){
+        return new CustomUserDetailsService(userRepository);
     }
 
     @Bean

--- a/src/main/java/com/poseidon/tradingapp/config/SpringSecurityConfiguration.java
+++ b/src/main/java/com/poseidon/tradingapp/config/SpringSecurityConfiguration.java
@@ -2,15 +2,10 @@ package com.poseidon.tradingapp.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration

--- a/src/main/java/com/poseidon/tradingapp/config/SpringSecurityConfiguration.java
+++ b/src/main/java/com/poseidon/tradingapp/config/SpringSecurityConfiguration.java
@@ -5,8 +5,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -16,12 +20,15 @@ public class SpringSecurityConfiguration {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(auth -> auth
-                        // on autorise explicitement TOUTES les routes de RuleController
-                        .requestMatchers("/rule/**", "/trade/**", "/bidList/**", "/curvePoint/**", "/rating/**", "/user/**" ).permitAll()
-                        // on autorise les ressources statiques
-                        .requestMatchers("/css/**", "/js/**", "/images/**").permitAll()
-                        // on autorise la racine également
-                        .requestMatchers("/").permitAll()
+                        // les ressources statiques restent publiques + la racine du projet
+                        .requestMatchers("/", "/css/**", "/js/**", "/images/**").permitAll()
+                        .requestMatchers("/app/login").permitAll()
+
+                        // accès ADMIN uniquement pour la gestion des utilisateurs
+                        .requestMatchers("/user/**").hasRole("ADMIN")
+
+                        // accès à tous les utilisateurs authentifiés (USER ou ADMIN)
+                        .requestMatchers("/bidList/**", "/curvePoint/**", "/trade/**", "/rating/**", "/rule/**").authenticated()
                         // tout le reste nécessitera une authentification
                         .anyRequest().authenticated()
                 )
@@ -31,8 +38,17 @@ public class SpringSecurityConfiguration {
                 // En phase de développement, on la désactive pour simplifier les tests des formulaires, car on n'a pas encore mis en place l'authentification complète ni l'injection du jeton CSRF dans les pages Thymeleaf.
                 // ATTENTION : À réactiver dès que les formulaires utilisateurs (login, création, etc.) seront finalisés.
                 .csrf(AbstractHttpConfigurer::disable)
-                // on active le formulaire de login par défaut
-                .formLogin(Customizer.withDefaults());
+                .formLogin(form -> form
+                        .loginPage("/app/login")             // page de login personnalisée
+                        .defaultSuccessUrl("/bidList/list", true)  // redirection après succès
+                        .failureUrl("/app/login?error=true") // gestion des erreurs
+                        .permitAll()
+                )
+                .logout(logout -> logout
+                        .logoutUrl("/app-logout")            // action logout
+                        .logoutSuccessUrl("/")               // après déconnexion → home
+                        .permitAll()
+                );
 
         return http.build();
     }

--- a/src/main/java/com/poseidon/tradingapp/config/SpringSecurityConfiguration.java
+++ b/src/main/java/com/poseidon/tradingapp/config/SpringSecurityConfiguration.java
@@ -11,9 +11,46 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
+/**
+ * Configuration centrale de Spring Security pour l'ensemble de l'application PCS_TradingApp
+ * <p>Cette classe :
+ *     <ul>
+ *       <li>Définit les règles d'accès aux différentes URL</li>
+ *      <li>Configure la page de Login personnalisée</li>
+ *      <li>Active l'authentification basée sur les utilisateurs stockés en base MySQL</li>
+ *      <li>Enregistre le filtre de sécurité principal (SecurityFilterChain)</li>
+ *      <li>Déclare le PasswordEncoder (BCrypt)</li>
+ *     </ul>
+ * </p>
+ * <p>
+ *     Règles d'accès :
+ *     <ul>
+ *         <li>Accès public : Ressources statiques, "/", page de login</li>
+ *         <li>Accès réservé ADMIN : /user/**</li>
+ *         <li>Accès authentifié (USER ou ADMIN) : bidlist, trade, rating, curvepoint et rule</li>
+ *     </ul>
+ * </p>
+ * <p>
+ *     Remarque : La protection CSRF est désactivée temporairement pour les tests et la simplification du dév.
+ *     Elle pourra être réactivée si nécessaire.
+ * </p>
+ */
 @Configuration
 public class SpringSecurityConfiguration {
-
+    /**
+     * Cette méthode configure :
+     * <ul>
+     * <li>Les règles d'autorisation (public, authentifié, ADMIN uniquement)</li>
+     * <li>La page de login personnalisée</li>
+     * <li>La gestion de l'erreur 403</li>
+     * <li>Le mécanisme de Logout</li>
+     * <li>La désactivation temporaire du CSRF</li>
+     * </ul>
+     *
+     * @param http objet HttpSecurity fourni par Spring Security
+     * @return SecurityFilterChain retourné
+     * @throws Exception
+     */
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
@@ -50,17 +87,28 @@ public class SpringSecurityConfiguration {
                         .logoutUrl("/app-logout")            // action logout
                         .logoutSuccessUrl("/")               // après déconnexion → home
                         .permitAll()
-        );
+                );
 
         return http.build();
     }
 
+    /**
+     * Fournit une implémentation personnalisée de {@link UserDetailsService} permettant à Spring Security de
+     * charger les utilisateurs depuis la base MySQL (username, mot de passe BCrypt, rôle)
+     * @param userRepository repository d'accès à la table users
+     * @return une instance de {@link CustomUserDetailsService}
+     */
     // Active l'authentification Spring Security via les utilisateurs stockés en base MySQL (username, mot de passe BCrypt, rôle)
     @Bean
-    public UserDetailsService userDetailsService(UserRepository userRepository){
+    public UserDetailsService userDetailsService(UserRepository userRepository) {
         return new CustomUserDetailsService(userRepository);
     }
 
+    /**
+     * Déclare le PasswordEncoder utilisé pour hasher les mots de passe
+     * BCrypt est l'algorithme recommandé par Spring Security
+     * @return PasswordEncoder basé sur BCrypt
+     */
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();

--- a/src/main/java/com/poseidon/tradingapp/dto/UserDto.java
+++ b/src/main/java/com/poseidon/tradingapp/dto/UserDto.java
@@ -1,6 +1,7 @@
 package com.poseidon.tradingapp.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +16,10 @@ public class UserDto {
     @Size(min = 4, max = 20, message = "Le username doit contenir entre 4 et 20 caractères")
     private String username;
     @NotBlank(message = "Le password est obligatoire")
-    @Size(min = 4, message = "Le password doit contenir au moins 4 caractères")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&._-])[A-Za-z\\d@$!%*?&._-]{8,}$",
+            message = "Le mot de passe doit contenir au moins 8 caractères dont une majuscule, une minuscule, un chiffre et un caractère spécial"
+    )
     private String password;
     @NotBlank(message = "Le fullname est obligatoire")
     @Size(min = 3, max = 30, message = "Le fullname doit contenir entre 3 et 30 caractères")

--- a/src/main/java/com/poseidon/tradingapp/repositories/UserRepository.java
+++ b/src/main/java/com/poseidon/tradingapp/repositories/UserRepository.java
@@ -4,7 +4,12 @@ import com.poseidon.tradingapp.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
+import java.util.Optional;
+
 
 public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecificationExecutor<User> {
 
+    // Méthode dérivée Spring Data JPA : équivalent de "SELECT * FROM users WHERE username = ?" car username est un champ dans mon entité "User".
+    // Spring génère automatiquement la requête à partir du nom de méthode.
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/java/com/poseidon/tradingapp/security/CustomUserDetailsService.java
+++ b/src/main/java/com/poseidon/tradingapp/security/CustomUserDetailsService.java
@@ -5,9 +5,7 @@ import com.poseidon.tradingapp.repositories.UserRepository;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.stereotype.Service;
 
-@Service
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final UserRepository userRepository;
@@ -18,9 +16,15 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        System.out.println("Spring Security cherche l'utilisateur : " + username);
+
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() ->
                         new UsernameNotFoundException("Utilisateur non trouvé : " + username));
+
+
+        System.out.println("Utilisateur trouvé : " + user.getUsername() + ", rôle = " + user.getRole());
 
         // Conversion de notre User JPA vers un UserDetails Spring Security
         return org.springframework.security.core.userdetails.User

--- a/src/main/java/com/poseidon/tradingapp/security/CustomUserDetailsService.java
+++ b/src/main/java/com/poseidon/tradingapp/security/CustomUserDetailsService.java
@@ -2,10 +2,26 @@ package com.poseidon.tradingapp.security;
 
 import com.poseidon.tradingapp.domain.User;
 import com.poseidon.tradingapp.repositories.UserRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
+/**
+ * Implémentation personnalisée de {@link UserDetailsService} utilisée par Spring Security pour
+ * charger un utilisateur depuis la base MySQL lors de l'authentification
+ *
+ * <p>
+ * Cette classe convertit un objet {@link User} (entité JPA)
+ * en {@link org.springframework.security.core.userdetails.User} (objet de Spring Security)
+ * </p>
+ *
+ * <p>
+ *     Les rôles stockés en base (ex : "ADMIN") sont automatiquement mappés vers les authorities Spring Security (ex : "ROLE_ADMIN")
+ *     via la méthode {@code roles()}
+ * </p>
+ */
+@Slf4j
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final UserRepository userRepository;
@@ -14,17 +30,34 @@ public class CustomUserDetailsService implements UserDetailsService {
         this.userRepository = userRepository;
     }
 
+    /**
+     * Charge un utilisateur via son username
+     * Méthode appelée automatiquement par Spring Security lors du login
+     * <p>
+     *     Étapes :
+     *     <ul>
+     *         <li>Recherche de l'utilisateur en base via UserRepository</li>
+     *         <li>Lance une {@link com.poseidon.tradingapp.exceptions.UserNotFoundException}, si absent</li>
+     *         <li>Conversion vers un objet UserDetails compris par Spring Security</li>
+     *         <li>Ajout automatique du préfixe "ROLE_" grâce à {@code roles(user.getRole())}</li>
+     *     </ul>
+     *
+     * </p>
+     * @param username nom d'utilisateur fournir lors du login
+     * @return un UserDetails requis par Spring Security
+     * @throws UsernameNotFoundException si aucun utilisateur n'existe avec ce username
+     */
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 
-        System.out.println("Spring Security cherche l'utilisateur : " + username);
+        log.debug("Spring Security cherche l'utilisateur : {}", username);
 
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() ->
                         new UsernameNotFoundException("Utilisateur non trouvé : " + username));
 
 
-        System.out.println("Utilisateur trouvé : " + user.getUsername() + ", rôle = " + user.getRole());
+        log.debug("Utilisateur trouvé : {}, rôle = {}", user.getUsername(), user.getRole());
 
         // Conversion de notre User JPA vers un UserDetails Spring Security
         return org.springframework.security.core.userdetails.User

--- a/src/main/java/com/poseidon/tradingapp/security/CustomUserDetailsService.java
+++ b/src/main/java/com/poseidon/tradingapp/security/CustomUserDetailsService.java
@@ -1,0 +1,32 @@
+package com.poseidon.tradingapp.security;
+
+import com.poseidon.tradingapp.domain.User;
+import com.poseidon.tradingapp.repositories.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() ->
+                        new UsernameNotFoundException("Utilisateur non trouvé : " + username));
+
+        // Conversion de notre User JPA vers un UserDetails Spring Security
+        return org.springframework.security.core.userdetails.User
+                .withUsername(user.getUsername())
+                .password(user.getPassword())       // déjà hashé (BCrypt)
+                .roles(user.getRole())              // ex: "ADMIN" ou "USER"
+                .build();
+    }
+}

--- a/src/main/java/com/poseidon/tradingapp/services/UserService.java
+++ b/src/main/java/com/poseidon/tradingapp/services/UserService.java
@@ -49,6 +49,13 @@ public class UserService {
     // ============================================================
     // CREATE
     // ============================================================
+
+    /**
+     * Crée un nouvel utilisateur
+     * <p>Le mot de passe fourni dans le DTO est automatiquement hashé via BCrypt avant d'être sauvegardé en base</p>
+     * @param dto données utilisateur
+     * @return UserDto correspondant à l'utilisateur sauvegardé
+     */
     public UserDto create(UserDto dto) {
         User entity = userMapper.toEntity(dto);
 
@@ -64,6 +71,15 @@ public class UserService {
     // ============================================================
     // UPDATE
     // ============================================================
+
+    /**
+     * Met à jour un utilisateur existant
+     * <p>Si un nouveau mot de passe est fourni, celui-ci est hashé et remplace l'ancien</p>
+     * <p>Si le mot de passe est null ou vide, l'ancien hash est conservé</p>
+     * @param id identifiant de l'utilisateur
+     * @param dto données modifiées
+     * @return UserDto mis à jour
+     */
     public UserDto update(Integer id, UserDto dto) {
         User existing = userRepository.findById(id)
                 .orElseThrow(() ->

--- a/src/main/java/com/poseidon/tradingapp/services/UserService.java
+++ b/src/main/java/com/poseidon/tradingapp/services/UserService.java
@@ -72,8 +72,14 @@ public class UserService {
         // Update via MapStruct
         userMapper.updateEntityFromDto(dto, existing);
 
-        // Re-hash du mot de passe
-        existing.setPassword(passwordEncoder.encode(dto.getPassword()));
+        // Gestion du mot de passe
+        if (dto.getPassword() != null && !dto.getPassword().isBlank()) {
+            // Si un nouveau mot de passe a été saisi → re-hash
+            existing.setPassword(passwordEncoder.encode(dto.getPassword()));
+        } else {
+            // Sinon → conserver l'ancien mot de passe
+            log.debug("Mot de passe non modifié pour l'utilisateur id={}", id);
+        }
 
         User updated = userRepository.save(existing);
         log.info("Utilisateur mis à jour : id={}", updated.getUserId());

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -22,7 +22,8 @@ spring.datasource.password=${DB_PASSWORD}
 # Configuration Hibernate / JPA
 # ==========================================
 # Exécute toujours les scripts SQL d'initialisation (même pour MySQL ou PostgreSQL, pas seulement pour les bases embarquées 'H2')
-spring.sql.init.mode=always
+# Premier lancement (spring.sql.init.mode=ALWAYS) Puis Lancements suivants (spring.sql.init.mode=NEVER)
+spring.sql.init.mode=NEVER
 
 # Chemins des scripts de création et d'alimentation
 # Indique le chemin du fichier SQL qui contient la création du schéma (tables, contraintes, clés primaires, etc.)

--- a/src/main/resources/database/data.sql
+++ b/src/main/resources/database/data.sql
@@ -1,13 +1,20 @@
--- ===============================================
--- Jeu de données initial pour la table users
--- Les mots de passe sont déjà hachés avec BCrypt :
---    - "admin" → mot de passe : admin (haché)
---    - "user"  → mot de passe : user (haché)
--- Ces comptes servent uniquement pour le développement local et la démo.
--- Ils ne sont pas utilisés dans l'environnement de test automatisé.
--- ===============================================
+-- =====================================================================
+-- Jeu de données initial (ENVIRONNEMENT DEV)
+--
+-- Deux comptes applicatifs basiques sont créés pour permettre de se connecter dès le premier lancement de l'application :
+--
+--   • username = admin  (role ADMIN)
+--   • username = user   (role USER)
+--
+-- Les mots de passe ci-dessous sont *déjà hachés en BCrypt*.
+-- Leur valeur réelle n'est PAS exposée dans ce fichier mais uniquement dans la documentation interne
+--
+-- IMPORTANT :
+-- Ce fichier est utilisé UNIQUEMENT dans l'environnement DEV.
+-- L'environnement TEST utilise un data.sql séparé.
+-- =====================================================================
 
 insert into users(fullname, username, password, role)
-values("Administrator", "admin", "$2a$12$IFMtLs5EJBx7OHDS.NT9V.N1UUne4scxE5QDkDQ9sfb2rXQlP3a1i", "ADMIN");
+values("Administrator", "admin", "$2a$15$yXmYdZrsrHePWXjikOx3EujPPQI.YNgupgdCvsPOhZVGIR5Mfk/xe", "ADMIN");
 insert into users(fullname, username, password, role)
-values("User", "user", "$2a$12$QQJDp4HysO3sRboNJXaUZuU4bEXnTjj7OLsGP0YPzOFTHUCRshoDe", "USER");
+values("User", "user", "$2a$15$4I9Hsjx.kwLK8T/2wEJcoueyfu193Yi67n2qWGD0U/UL0PN/nv5Fy", "USER");

--- a/src/main/resources/database/schema.sql
+++ b/src/main/resources/database/schema.sql
@@ -1,4 +1,16 @@
--- Création des tables
+-- ============================================================================
+-- SCHEMA SQL - ENVIRONNEMENT DEV
+-- ----------------------------------------------------------------------------
+-- Exécuté uniquement lors du premier démarrage (spring.sql.init.mode=always).
+-- En DEV, la base ne doit PAS être écrasée à chaque lancement.
+--
+-- Par conséquent :
+--   - "CREATE TABLE IF NOT EXISTS" est utilisé → évite les erreurs si la table existe
+--   - La contrainte UNIQUE est définie directement dans le CREATE (plus simple)
+--
+-- Objectif : initialiser la base une seule fois sans perturber les données existantes lors des redémarrages en développement.
+-- ============================================================================
+
 CREATE TABLE IF NOT EXISTS bid_list (
   bid_list_id INT NOT NULL AUTO_INCREMENT,
   account VARCHAR(30) NOT NULL,
@@ -90,10 +102,12 @@ CREATE TABLE IF NOT EXISTS rule (
 
 CREATE TABLE IF NOT EXISTS users (
   user_id INT NOT NULL AUTO_INCREMENT,
-  username VARCHAR(125),
-  password VARCHAR(125),
-  fullname VARCHAR(125),
-  role VARCHAR(125),
+  username VARCHAR(125) NOT NULL,
+  password VARCHAR(125) NOT NULL,
+  fullname VARCHAR(125) NOT NULL,
+  role VARCHAR(125) NOT NULL,
 
-  PRIMARY KEY (user_id)
+  PRIMARY KEY (user_id),
+  UNIQUE INDEX `username_UNIQUE` (username)
 );
+

--- a/src/main/resources/templates/403.html
+++ b/src/main/resources/templates/403.html
@@ -1,16 +1,19 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
-      <title>Spring Boot</title>
+	<title>Accès refusé - PCS Trading</title>
 </head>
 <body>
-   <h3>Access Denied Exception</h3>
-   <div>
-	    Logged in user: <b th:inline="text"  class="user"> [[${#httpServletRequest.remoteUser}]] </b>
-	    <form th:action="@{/app-logout}" method="POST">
-	         <input type="submit" value="Logout"/>
-	    </form>
-   </div> 	 
-    <p class="error" th:text="${errorMsg}">Error</p>
+<h3>Access Denied Exception</h3>
+<div>
+	Logged in user:
+	<b class="user" sec:authentication="name">username</b>
+	<form th:action="@{/app-logout}" method="POST">
+		<input type="submit" value="Logout"/>
+	</form>
+</div>
+<p class="error" th:text="${errorMsg}">Error</p>
 </body>
 </html>   

--- a/src/main/resources/templates/bidList/list.html
+++ b/src/main/resources/templates/bidList/list.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:th="http://www.thymeleaf.org">
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.w3.org/1999/xhtml">
 <head>
 	<meta charset="utf-8"/>
 	<title>BidList List</title>
@@ -17,15 +18,12 @@
 			<a href="/rule/list">Rule</a>
 		</div>
 		<div class="col-6 text-right">
-			<!-- Partie login désactivée temporairement -->
-			<!--/*
-			Logged in user: <b th:inline="text"  class="user"> [[${#httpServletRequest.remoteUser}]] </b>
-			<form th:action="@{/app-logout}" method="POST">
-				<input type="submit" value="Logout"/>
+			Logged in user:
+			<b class="user" sec:authentication="name">username</b>
+			
+			<form th:action="@{/app-logout}" method="POST" style="display:inline;">
+				<button type="submit" class="btn btn-link p-0 m-0">Logout</button>
 			</form>
-			*/-->
-			<!-- Remplacement temporaire -->
-			Logged in user: <b>Anonymous</b>
 		</div>
 	</div>
 	<div class="row"><h2>Bid List</h2></div>

--- a/src/main/resources/templates/curvePoint/list.html
+++ b/src/main/resources/templates/curvePoint/list.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:th="http://www.thymeleaf.org">
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.w3.org/1999/xhtml">
 <head>
 	<meta charset="utf-8"/>
 	<title>CurvePoint List</title>
@@ -17,15 +18,12 @@
 			<a href="/rule/list">Rule</a>
 		</div>
 		<div class="col-6 text-right">
-			<!-- Partie login désactivée temporairement -->
-			<!--/*
-			Logged in user: <b th:inline="text"  class="user"> [[${#httpServletRequest.remoteUser}]] </b>
-			<form th:action="@{/app-logout}" method="POST">
-				<input type="submit" value="Logout"/>
+			Logged in user:
+			<b class="user" sec:authentication="name">username</b>
+			
+			<form th:action="@{/app-logout}" method="POST" style="display:inline;">
+				<button type="submit" class="btn btn-link p-0 m-0">Logout</button>
 			</form>
-			*/-->
-			<!-- Remplacement temporaire -->
-			Logged in user: <b>Anonymous</b>
 		</div>
 	</div>
 	<div class="row"><h2>Curve Point List</h2></div>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<title>Login</title>
+	<link rel="stylesheet" href="/css/styles.css"/>
+</head>
+<body>
+<h2>Connexion</h2>
+<div th:if="${param.error}">
+	<p style="color:red;">Identifiants invalides</p>
+</div>
+
+<form th:action="@{/app/login}" method="post">
+	
+	<label>Nom d'utilisateur :</label>
+	<input type="text" name="username"/><br/><br/>
+	
+	<label>Mot de passe :</label>
+	<input type="password" name="password"/><br/><br/>
+	
+	<button type="submit">Se connecter</button>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/rating/list.html
+++ b/src/main/resources/templates/rating/list.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:th="http://www.thymeleaf.org">
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.w3.org/1999/xhtml">
 <head>
 	<meta charset="utf-8"/>
 	<title>Rating List</title>
@@ -17,15 +18,12 @@
 			<a th:href="@{/rule/list}">Rule</a>
 		</div>
 		<div class="col-6 text-right">
-			<!-- Partie login désactivée temporairement -->
-			<!--/*
-			Logged in user: <b th:inline="text"  class="user"> [[${#httpServletRequest.remoteUser}]] </b>
-			<form th:action="@{/app-logout}" method="POST">
-				<input type="submit" value="Logout"/>
+			Logged in user:
+			<b class="user" sec:authentication="name">username</b>
+			
+			<form th:action="@{/app-logout}" method="POST" style="display:inline;">
+				<button type="submit" class="btn btn-link p-0 m-0">Logout</button>
 			</form>
-			*/-->
-			<!-- Remplacement temporaire -->
-			Logged in user: <b>Anonymous</b>
 		</div>
 	</div>
 	

--- a/src/main/resources/templates/rule/list.html
+++ b/src/main/resources/templates/rule/list.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:th="http://www.thymeleaf.org">
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.w3.org/1999/xhtml">
 <head>
 	<meta charset="utf-8"/>
 	<title>Rule List</title>
@@ -25,16 +26,12 @@
 			<a href="/rule/list">Rule</a>
 		</div>
 		<div class="col-6 text-right">
-			<!-- Partie login désactivée temporairement -->
-			<!--/*
-			Logged in user: <b th:inline="text" class="user"> [[${#httpServletRequest.remoteUser}]] </b>
-			<form th:action="@{/app-logout}" method="POST">
-				<input type="submit" value="Logout"/>
-			</form>
-			*/-->
+			Logged in user:
+			<b class="user" sec:authentication="name">username</b>
 			
-			<!-- Remplacement temporaire -->
-			Logged in user: <b>Anonymous</b>
+			<form th:action="@{/app-logout}" method="POST" style="display:inline;">
+				<button type="submit" class="btn btn-link p-0 m-0">Logout</button>
+			</form>
 		</div>
 	</div>
 	<div class="row"><h2>Rule List</h2></div>

--- a/src/main/resources/templates/trade/list.html
+++ b/src/main/resources/templates/trade/list.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:th="http://www.thymeleaf.org">
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.w3.org/1999/xhtml">
 <head>
 	<meta charset="utf-8"/>
 	<title>Trade List</title>
@@ -17,15 +18,12 @@
 			<a href="/rule/list">Rule</a>
 		</div>
 		<div class="col-6 text-right">
-			<!-- Partie login désactivée temporairement -->
-			<!--/*
-			Logged in user: <b th:inline="text"  class="user"> [[${#httpServletRequest.remoteUser}]] </b>
-			<form th:action="@{/app-logout}" method="POST">
-				<input type="submit" value="Logout"/>
+			Logged in user:
+			<b class="user" sec:authentication="name">username</b>
+			
+			<form th:action="@{/app-logout}" method="POST" style="display:inline;">
+				<button type="submit" class="btn btn-link p-0 m-0">Logout</button>
 			</form>
-			*/-->
-			<!-- Remplacement temporaire -->
-			Logged in user: <b>Anonymous</b>
 		</div>
 	</div>
 	<div class="row"><h2>Trade List</h2></div>

--- a/src/test/java/com/poseidon/tradingapp/controllers/UserControllerIT.java
+++ b/src/test/java/com/poseidon/tradingapp/controllers/UserControllerIT.java
@@ -253,4 +253,27 @@ public class UserControllerIT {
                 .andExpect(redirectedUrl("/user/list"))
                 .andExpect(flash().attributeExists("errorMessage"));
     }
+
+    // ============================================================
+    // SECURITY - USER cannot access /user/list
+    // ============================================================
+    @Test
+    @WithMockUser(username = "bob_user", roles = "USER")
+    void shouldDenyAccessToUserListForNonAdmin() throws Exception {
+
+        mockMvc.perform(get("/user/list"))
+                .andExpect(status().isForbidden()); // 403 = accès refusé
+    }
+
+    // ============================================================
+    // SECURITY - ADMIN can access /user/list
+    // ============================================================
+    @Test
+    @WithMockUser(username = "bob_admin", roles = "ADMIN")
+    void shouldAllowAccessToUserListForAdmin() throws Exception {
+
+        mockMvc.perform(get("/user/list"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("user/list"));
+    }
 }

--- a/src/test/java/com/poseidon/tradingapp/controllers/UserControllerIT.java
+++ b/src/test/java/com/poseidon/tradingapp/controllers/UserControllerIT.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.Matchers.hasSize;
@@ -18,6 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 @WithMockUser(username = "admin", roles = "ADMIN")
 public class UserControllerIT {
 

--- a/src/test/java/com/poseidon/tradingapp/controllers/UserControllerIT.java
+++ b/src/test/java/com/poseidon/tradingapp/controllers/UserControllerIT.java
@@ -44,7 +44,7 @@ public class UserControllerIT {
         user.setUsername("Cindy");
         user.setFullname("Cindy Crawford");
         user.setRole("USER");
-        user.setPassword("558899");
+        user.setPassword("558899"); // utilisé uniquement en base de test, pas pour la validation DTO
 
         User saved = userRepository.save(user);
 
@@ -75,12 +75,15 @@ public class UserControllerIT {
     // ============================================================
     @Test
     void shouldAddUserWhenSuccess() throws Exception {
+        // mot de passe conforme à la regex : au moins 8 car., une maj, une min, un chiffre, un spécial
+        String strongPassword = "TestUser1!";
+
         //when + then
         mockMvc.perform(post("/user/validate")
                         .param("fullname", "Jade BH")
                         .param("username", "Jade")
                         .param("role", "USER")
-                        .param("password", "654789")
+                        .param("password", strongPassword)
                 )
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/user/list"))
@@ -93,12 +96,15 @@ public class UserControllerIT {
     // ============================================================
     @Test
     void shouldNotAddUserWhenError() throws Exception {
+        // username vide → validation doit échouer
+        String strongPassword = "TestUser1!";
+
         //when + then
         mockMvc.perform(post("/user/validate")
                         .param("fullname", " Hammar")
                         .param("username", "")// invalide
                         .param("role", "USER")
-                        .param("password", "684719")
+                        .param("password", strongPassword) // valide, pour isoler l'erreur sur username
                 )
                 .andExpect(status().isOk()) // retour normal
                 .andExpect(view().name("user/add")) // retour au formulaire
@@ -116,7 +122,7 @@ public class UserControllerIT {
         user.setUsername("cindy");
         user.setFullname("Cindy Crawford");
         user.setRole("USER");
-        user.setPassword("1234");
+        user.setPassword("1234"); // ici, on passe par l'entité directement, pas par le DTO
 
         User saved = userRepository.save(user);
 
@@ -151,11 +157,13 @@ public class UserControllerIT {
         user.setPassword("1234");
         User saved = userRepository.save(user);
 
+        String strongPassword = "TestUser1!";
+
         mockMvc.perform(post("/user/update/" + saved.getUserId())
                         .param("username", "Cino")
                         .param("fullname", "Cindy Updated")
                         .param("role", "ADMIN")
-                        .param("password", "9999"))
+                        .param("password", strongPassword))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/user/list"))
                 .andExpect(flash().attributeExists("successMessage"));
@@ -180,11 +188,14 @@ public class UserControllerIT {
         user.setPassword("1234");
         User saved = userRepository.save(user);
 
+        String strongPassword = "TestUser1!";
+
         mockMvc.perform(post("/user/update/" + saved.getUserId())
                         .param("username", "") // invalide
                         .param("fullname", "Cindy")
                         .param("role", "USER")
-                        .param("password", "1234"))
+                        .param("password", strongPassword) // valide → l'erreur porte sur username
+                )
                 .andExpect(status().isOk())
                 .andExpect(view().name("user/update"))
                 .andExpect(model().attributeExists("user"));
@@ -197,11 +208,14 @@ public class UserControllerIT {
     @Test
     void shouldRedirectUpdateWhenUserNotFound() throws Exception {
 
+        String strongPassword = "TestUser1!";
+
         mockMvc.perform(post("/user/update/999")
                         .param("username", "test")
                         .param("fullname", "Test Test")
                         .param("role", "USER")
-                        .param("password", "1234"))
+                        .param("password", strongPassword)
+                )
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/user/list"))
                 .andExpect(flash().attributeExists("errorMessage"));

--- a/src/test/java/com/poseidon/tradingapp/repositories/UserRepositoryIT.java
+++ b/src/test/java/com/poseidon/tradingapp/repositories/UserRepositoryIT.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -22,15 +24,19 @@ public class UserRepositoryIT {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
-    private User user;
-
     @BeforeEach
-    void setup() {
-        user = new User();
-        user.setUsername("sue");
-        user.setFullname("Sue BDH");
-        user.setRole("USER");
-        user.setPassword(passwordEncoder.encode("123"));
+    void cleanDatabase() {
+        userRepository.deleteAll();
+    }
+
+    // Helper pour créer un user propre
+    private User buildUser(String username, String fullname, String role, String rawPassword) {
+        User u = new User();
+        u.setUsername(username);
+        u.setFullname(fullname);
+        u.setRole(role);
+        u.setPassword(passwordEncoder.encode(rawPassword));
+        return u;
     }
 
     // ============================================================
@@ -38,10 +44,12 @@ public class UserRepositoryIT {
     // ============================================================
     @Test
     void shouldCreateUser() {
+        User user = buildUser("sue_create", "Sue BDH", "USER", "123");
+
         User saved = userRepository.save(user);
 
         assertNotNull(saved.getUserId());
-        assertEquals("sue", saved.getUsername());
+        assertEquals("sue_create", saved.getUsername());
         assertTrue(passwordEncoder.matches("123", saved.getPassword()));
     }
 
@@ -50,13 +58,13 @@ public class UserRepositoryIT {
     // ============================================================
     @Test
     void shouldFindUserById() {
-        User saved = userRepository.save(user);
+        User saved = userRepository.save(buildUser("sue_read", "Sue BDH", "USER", "123"));
 
         Optional<User> result = userRepository.findById(saved.getUserId());
         assertTrue(result.isPresent());
 
         User found = result.get();
-        assertEquals("sue", found.getUsername());
+        assertEquals("sue_read", found.getUsername());
         assertEquals("Sue BDH", found.getFullname());
         assertTrue(passwordEncoder.matches("123", found.getPassword()));
     }
@@ -66,7 +74,7 @@ public class UserRepositoryIT {
     // ============================================================
     @Test
     void shouldUpdateUser() {
-        User saved = userRepository.save(user);
+        User saved = userRepository.save(buildUser("sue_update", "Sue BDH", "USER", "123"));
 
         saved.setFullname("Sousou Updated");
         saved.setPassword(passwordEncoder.encode("456"));
@@ -84,7 +92,7 @@ public class UserRepositoryIT {
     // ============================================================
     @Test
     void shouldDeleteUser() {
-        User saved = userRepository.save(user);
+        User saved = userRepository.save(buildUser("sue_delete", "Sue BDH", "USER", "123"));
 
         userRepository.deleteById(saved.getUserId());
 

--- a/src/test/resources/database/data.sql
+++ b/src/test/resources/database/data.sql
@@ -2,6 +2,7 @@
 -- Jeu de données à remplir ultérieurement
 -- (utilisé uniquement pour les tests automatisés)
 -- ===============================================
+truncate table users ;
 
 insert into users(fullname, username, password, role)
 values("Administrator", "admin", "$2a$12$IFMtLs5EJBx7OHDS.NT9V.N1UUne4scxE5QDkDQ9sfb2rXQlP3a1i", "ADMIN");

--- a/src/test/resources/database/data.sql
+++ b/src/test/resources/database/data.sql
@@ -1,10 +1,19 @@
--- ===============================================
--- Jeu de données à remplir ultérieurement
--- (utilisé uniquement pour les tests automatisés)
--- ===============================================
+-- =====================================================================
+-- Jeu de données initial (ENVIRONNEMENT TEST)
+--
+-- Deux comptes applicatifs minimaux sont créés :
+--   • username = admin  (role ADMIN)
+--   • username = user   (role USER)
+--
+-- Les mots de passe sont déjà hachés en BCrypt et leur valeur réelle n'est PAS exposée dans ce fichier.
+--
+-- IMPORTANT :
+-- Ce fichier est utilisé UNIQUEMENT dans l'environnement TEST.
+-- L'environnement DEV possède son propre data.sql distinct.
+-- =====================================================================
 truncate table users ;
 
 insert into users(fullname, username, password, role)
-values("Administrator", "admin", "$2a$12$IFMtLs5EJBx7OHDS.NT9V.N1UUne4scxE5QDkDQ9sfb2rXQlP3a1i", "ADMIN");
+values("Administrator", "admin", "$2a$15$LjCcKMcSnwMYFjLgXApkfub5UioHqpF4wknxPGV98JwlUCTWxydea", "ADMIN");
 insert into users(fullname, username, password, role)
-values("User", "user", "$2a$12$QQJDp4HysO3sRboNJXaUZuU4bEXnTjj7OLsGP0YPzOFTHUCRshoDe", "USER");
+values("User", "user", "$2a$15$l3YOUR6OejSiijPYchJ5huwkJyyoUBuQR9roc1B76jGEGF32XHu7m", "USER");

--- a/src/test/resources/database/schema.sql
+++ b/src/test/resources/database/schema.sql
@@ -1,3 +1,17 @@
+-- ============================================================================
+-- SCHEMA SQL - ENVIRONNEMENT TEST
+-- ----------------------------------------------------------------------------
+-- Important :
+-- Ce schéma est exécuté plusieurs fois lors des tests d'intégration.
+-- Contrairement à l'environnement DEV, le contexte Spring Boot est rechargé entre certains tests (@DirtiesContext), ce qui implique :
+--
+--   - DROP TABLE obligatoire → garantit une base propre avant chaque création
+--   - CREATE TABLE sans "IF NOT EXISTS" → évite que le script soit ignoré
+--   - Contrainte UNIQUE ajoutée via ALTER TABLE pour assurer sa présence même lorsque Spring recharge le contexte
+--
+-- Objectif : assurer des tests 100% reproductibles et isolés.
+-- ============================================================================
+
 -- Suppression des tables existantes pour garantir un schéma propre
 -- IMPORTANT : si des relations de clé étrangère sont ajoutées plus tard, toujours supprimer d'abord les tables "enfants" (celles qui
 -- contiennent les FOREIGN KEY) avant les tables "parents" (référencées), afin d'éviter les erreurs de contrainte.
@@ -100,10 +114,13 @@ CREATE TABLE rule (
 
 CREATE TABLE users (
   user_id INT NOT NULL AUTO_INCREMENT,
-  username VARCHAR(125),
-  password VARCHAR(125),
-  fullname VARCHAR(125),
-  role VARCHAR(125),
+  username VARCHAR(125) NOT NULL,
+  password VARCHAR(125) NOT NULL,
+  fullname VARCHAR(125) NOT NULL,
+  role VARCHAR(125) NOT NULL,
 
   PRIMARY KEY (user_id)
 );
+
+ALTER TABLE users
+    ADD CONSTRAINT username_unique UNIQUE (username);


### PR DESCRIPTION
## Résume du PR

Ce Pull Request implémente l'intégralité de la Story 7 :

- Mise en place de l'authentification Spring Security
- Gestion des rôles USER / ADMIN
- Hashage des mots de passe via BCrypt
- Page de login personnalisée
- Logout Spring Security
- Page d’accès refusé (403) si !=ADMIN
- Chargement des utilisateurs depuis MySQL
- Intégration Thymeleaf + Spring Security (sec:authorize / sec:authentication)
- Mise à jour du schéma SQL + données initiales
- Stabilisation des tests d'intégration avec deux tests de sécurité
- Documentation (Javadoc professionnelle)

## Contenu du PR (détail par commit)
**Commit 1 : fix(user): corriger la gestion du mot de passe dans update()**
- Ne hash le mot de passe que si un nouveau est fourni
- Conserve l’ancien mot de passe si champ vide
- Évite le hash du string vide

**Commit 2 : feat(security): ajouter la page login personnalisée**
- Création du template `login.html`
- Formulaire POST `/app/login` géré automatiquement par Spring Security
- Message d’erreur en cas d’échec `(?error=true)`
- Champs `username` et `password` compatibles Spring Security

**Commit 3 : feat(security): configurer les règles d’accès + login/logout**
- Définition des routes publiques (`/`, `/app/login`, `assets`)
- Protection `/user/**` → ADMIN
- Modules métiers accessibles aux utilisateurs authentifiés
- Logout sur `/app-logout`
- Redirection après succès du login

**Commit 4 : feat(security): ajouter CustomUserDetailsService (authentification MySQL)**
- Méthode `findByUsername` dans UserRepository
- Conversion User → UserDetails
- Gestion du rôle + mot de passe hashé
- Authentification entièrement basée sur la base MySQL

**Commit 5 : feat(security): intégration complète MySQL + Thymeleaf Security + 403 + SQL + tests**
- **Sécurité Spring**
  - Dépendance `thymeleaf-extras-springsecurity6`
  - Affichage du user connecté dans toutes les listes
  - Template `403.html` corrigé
  - Page d’erreur déclarée dans la config
- **Base de données**
  - Index UNIQUE sur username
  - Mise à jour des schema.sql (DEV + TEST)
  - Nettoyage strict TRUNCATE TABLE users dans data.sql de test
- **Tests**
  - Stabilisation complète des tests User (deleteAll + usernames uniques)
  - Ajout @ActiveProfiles("test")

**Commit 6**

- feat(user): validation forte des mots de passe + mise à jour DEV/TEST + corrections tests
- Ajout regex stricte dans `UserDto`
- Mise à jour des données initiales (passwords déjà hashés)
- Correction des tests MockMvc pour respecter la regex
- Commentaires pédagogiques sur DTO vs Entity

**Commit 7**

- test(security): tests d'accès basés sur les rôles
- USER → accès refusé `/user/list` (403)
- ADMIN → accès autorisé `/user/list`
- Valide la configuration Spring Security (hasRole("ADMIN"))

**Commit 8**

- docs(security): Javadoc complète Spring Security
- Documentation détaillée : règles d’accès, login/logout, CSRF, 403
- Javadoc dans CustomUserDetailsService
- Javadoc dans UserService sur la gestion sécurisée du mot de passe

## Clôture
Closes #25